### PR TITLE
toigraph() conversion changes

### DIFF
--- a/R/Igraph.R
+++ b/R/Igraph.R
@@ -184,8 +184,8 @@ toIgraph = function(rcx, directed=FALSE){
     edges = rcx$edges
     ## reordering columns so that source and target are the first two
     edgeNames = colnames(edges)
-    edgeNames = c("source","target", 
-                  (edgeNames[!edgeNames %in% c("source","target")]))
+    edgeNames = c("s","t", 
+                  (edgeNames[!edgeNames %in% c("s","t")]))
     edges = edges[edgeNames]
     ## rename columns to use id as name
     nodes = rcx$nodes

--- a/README.md
+++ b/README.md
@@ -909,6 +909,14 @@ As igraph, graphNEL objects can not hold information about the visual
 representation of the network, so here too we can restore the original
 layout by adding the `CyVisualProperties` aspect we saved previously.
 
+Errors, questions and suggestions
+=================================
+
+If you have any questions to the usage of this package, suggestions for the further development of this package or encountered any problems in the process of the installation or while the usage:
+
+Pleas feel free to open a new [issue on our bord](https://github.com/frankkramer-lab/RCX/issues)!
+
+
 Session info
 ============
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,31 @@ Model](vignettes/Appendix_The_RCX_and_CX_Data_Model.Rmd)
 Installation
 ============
 
+For installing packages from github the `devtools` package is the most common approach.
+However, it requires XML libraries installed on the system which can cause problems while installation due to unmet dependencies.
+The `remotes` package covers the functionality to download and install R packages stored in 'GitHub', 'GitLab', 'Bitbucket', 'Bioconductor', or plain 'subversion' or 'git' repositories without depending on XML libraries.
+If `devtools` is already installed, of course it can be used, otherwise it is recommended to use the lightweight `remotes` package.
+
+**From github using remotes:**
+
 ``` r
-if (!"RCX" %in% installed.packages()) {
-    require(devtools)
-    install_github("frankkramer-lab/RCX")
+if(!"remotes" %in% installed.packages()){
+  install.packages("remotes")
+}
+if(!"RCX" %in% installed.packages()){
+  remotes::install_github("frankkramer-lab/RCX")
+}
+library(RCX)
+```
+
+**From github using devtools:**
+
+``` r
+if(!"devtools" %in% installed.packages()){
+  install.packages("devtools")
+}
+if(!"RCX" %in% installed.packages()){
+  devtools::install_github("frankkramer-lab/RCX")
 }
 library(RCX)
 ```

--- a/vignettes/RCX_an_R_package_implementing_the_Cytoscape_Exchange_format.Rmd
+++ b/vignettes/RCX_an_R_package_implementing_the_Cytoscape_Exchange_format.Rmd
@@ -76,18 +76,41 @@ For an overview of the differences of the RCX implementation to the CX specifica
 
 # Installation
 
+For installing packages from github the `devtools` package is the most common approach.
+However, it requires XML libraries installed on the system which can cause problems while installation due to unmet dependencies.
+The `remotes` package covers the functionality to download and install R packages stored in 'GitHub', 'GitLab', 'Bitbucket', 'Bioconductor', or plain 'subversion' or 'git' repositories without depending on XML libraries.
+If `devtools` is already installed, of course it can be used, otherwise it is recommended to use the lightweight `remotes` package.
+
+**From github using remotes:**
+
 ```{r, eval=FALSE}
+if(!"remotes" %in% installed.packages()){
+  install.packages("remotes")
+}
 if(!"RCX" %in% installed.packages()){
-  require(devtools)
-  install_github("frankkramer-lab/RCX")
+  remotes::install_github("frankkramer-lab/RCX")
+}
+library(RCX)
+```
+
+**From github using devtools:**
+
+```{r, eval=FALSE}
+if(!"devtools" %in% installed.packages()){
+  install.packages("devtools")
+}
+if(!"RCX" %in% installed.packages()){
+  devtools::install_github("frankkramer-lab/RCX")
 }
 library(RCX)
 ```
 
 
 ```{r installBioconductor, eval=FALSE, include=FALSE}
-if(!"RCX" %in% installed.packages()){
+if(!"BiocManager" %in% installed.packages()){
   install.packages("BiocManager")
+}
+if(!"RCX" %in% installed.packages()){
   BiocManager::install("RCX")
 }
 library(RCX)


### PR DESCRIPTION
Currently ndex objects don't have the edge column labels that are referred to in this conversion function i.e. "source" and "target". 

Seems like this is reflected in the other conversion [function](https://github.com/frankkramer-lab/ndexr/blob/a8658a8450d44a3c198cbee746293ce1c765f7c9/R/ndex_RCXgraph.r#L90) that converts rcx to something igraph-like.
